### PR TITLE
Pin dotnet-core and dotnet-core-sdk pkgs to 2.2.3

### DIFF
--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -9,8 +9,8 @@ $pkg_description="NOP Commerce ASP.net core app"
 # Where the running service variable data is located - simplified run, no need for hook
 $pkg_svc_run="cd $pkg_svc_var_path;dotnet nop.web.dll"  
 
-$pkg_deps=@("core/dotnet-core")
-$pkg_build_deps=@("core/dotnet-core-sdk")
+$pkg_deps=@("core/dotnet-core/2.2.3")
+$pkg_build_deps=@("core/dotnet-core-sdk/2.2.301")
 
 
 $pkg_exports=@{


### PR DESCRIPTION
Package build started failing after we (Chef) updated the latest stable version of dotnet-core packages to 3.1. This update simply pins the versions to 2.2.3. The package builds successfully but I have not spun up the whole demo to test the change.